### PR TITLE
kernel support for fall analysis template

### DIFF
--- a/mj-decriminalization/analysis/README.MD
+++ b/mj-decriminalization/analysis/README.MD
@@ -22,7 +22,13 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-4. Open the notebook
+4. Install the IPython Kernel in the virtual environment.
+
+```
+python ipykernel install --user --name=venv --display-name "Python (venv)"
+```
+
+5. Open the notebook
 The notebook in the top level of the `analysis` folder is most recent.
 
 

--- a/mj-decriminalization/analysis/requirements.txt
+++ b/mj-decriminalization/analysis/requirements.txt
@@ -3,3 +3,5 @@ numpy
 seaborn
 matplotlib
 bokeh
+jupyter
+ipython


### PR DESCRIPTION
- adds ipython and jupyter as requirements
- adds kernel setup to readme

From what I have read, this should make the notebook work more reliably on different installs—I believe it was working on my end because I had these requirements installed globally already. The goal is portability.